### PR TITLE
refactor: Refactor dictionary import and lookup for Yomitan format

### DIFF
--- a/src/deinflector.ts
+++ b/src/deinflector.ts
@@ -24,15 +24,27 @@ const RULE_TYPES = new Map([
 	["iru", 0b01000000], // Intermediate -iru endings
 ]);
 
+type NormalizedVariant = [string, string, number, number];
+type NormalizedReason = [string, NormalizedVariant[]];
+
 // The logic here is adapted from Yomichan's deinflection code:
 // https://github.com/FooSoft/yomichan/blob/master/ext/js/language/deinflector.js
 export class Deinflector {
-	reasons: any[];
+	reasons: NormalizedReason[];
 
 	constructor() {
 		this.reasons = Deinflector.normalizeReasons(
 			DEINFLECT_DATA as unknown as Record<string, RawReason[]>
-		);
+		) as NormalizedReason[];
+	}
+
+	/**
+	 * Converts an array of rule strings (from dictionary entry or raw rule data) into a single bitmask number.
+	 * @param rules Array of rule strings (e.g., ["v5", "vi"]).
+	 * @returns Bitmask representing the combined rule flags.
+	 */
+	public getRuleFlags(rules: string[]): number {
+		return Deinflector.rulesToRuleFlags(rules);
 	}
 
 	deinflect(source: string): DeinflectionResult[] {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -11,7 +11,7 @@ declare global {
 		entries(): IterableIterator<AbstractRange>;
 		forEach(
 			callback: (range: AbstractRange, highlight: Highlight) => void,
-			thisArg?: any
+			thisArg?: unknown
 		): void;
 		has(range: AbstractRange): boolean;
 		keys(): IterableIterator<AbstractRange>;

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -1,7 +1,13 @@
 import { App, Platform, FileSystemAdapter, Notice } from "obsidian";
 import * as path from "path";
-import { DictionaryData } from "./types";
+import * as JSZip from "jszip";
 import { DictionaryManager } from "./manager";
+import {
+	RawTermEntry,
+	YomitanIndex,
+	ProcessedTerm,
+	RawDefinition,
+} from "./types";
 
 export class DictionaryImporter {
 	app: App;
@@ -25,104 +31,103 @@ export class DictionaryImporter {
 			);
 			return;
 		}
-
 		const adapter = this.app.vault.adapter as FileSystemAdapter;
-		const vaultBasePath = adapter.getBasePath();
-		const fullPath = path.join(vaultBasePath, this.pluginManifestDir);
+		const fullPath = path.join(
+			adapter.getBasePath(),
+			this.pluginManifestDir
+		);
 		const { shell } = require("electron");
 		shell.openPath(fullPath);
 	}
 
-	async importDictionary(languageCode: string) {
+	async importDictionary() {
 		const adapter = this.app.vault.adapter;
-		const searchPrefix = `jmdict-${languageCode}-`;
+
+		const listResult = await adapter.list(this.pluginManifestDir);
+		const zipFiles = listResult.files.filter(
+			(filePath) => path.extname(filePath).toLowerCase() === ".zip"
+		);
+
+		if (zipFiles.length === 0) {
+			new Notice("No .zip files found in plugin folder.");
+			return;
+		}
+
+		const targetZip = zipFiles[0];
+		console.log("Importing", targetZip);
 
 		try {
-			const listResult = await adapter.list(this.pluginManifestDir);
-			const dictionaryPath = listResult.files.find((filePath) => {
-				const fileName = path.basename(filePath);
-				return (
-					fileName.startsWith(searchPrefix) &&
-					fileName.endsWith(".json")
-				);
-			});
-			console.log("Found dictionary file:", dictionaryPath);
-
-			if (!dictionaryPath) {
-				new Notice(
-					`No dictionary file found for the selected language. Please ensure the file is in the plugin folder.`
-				);
-				return;
-			}
-
-			const db = await this.dictionaryManager.getDB();
-
-			const existingVersion = await db.get("metadata", "version");
-			const fileContent = await adapter.read(dictionaryPath);
-			const dictionaryData: DictionaryData = JSON.parse(fileContent);
-
-			if (existingVersion?.value === dictionaryData.version) {
-				console.log("Dictionary already imported, skipping");
-				new Notice("Dictionary already imported");
-				return;
-			}
-
-			new Notice("Importing dictionary... This may take a moment.");
-			await this.convertDictionaryToMap(dictionaryData);
+			const arrayBuffer = await adapter.readBinary(targetZip);
+			await this.processZip(arrayBuffer);
 			new Notice("Dictionary imported successfully!");
 		} catch (error) {
 			new Notice(
-				`Error importing dictionary: ${
-					(error as Error).message || error
-				}`
+				`Error importing dictionary: ${(error as Error).message}`
 			);
 			console.error("Error importing dictionary:", error);
 		}
 	}
 
-	private async convertDictionaryToMap(dictionaryData: DictionaryData) {
+	private async processZip(data: ArrayBuffer) {
+		const zip = await JSZip.loadAsync(data);
+
+		const indexFile = zip.file("index.json");
+		if (!indexFile)
+			throw new Error("Invalid Yomitan dictionary: index.json missing");
+
+		const indexContent = await indexFile.async("string");
+		const meta: YomitanIndex = JSON.parse(indexContent);
+
 		const db = await this.dictionaryManager.getDB();
 
-		await db.clear("entries");
-		await db.clear("metadata");
-
-		const tx = db.transaction("entries", "readwrite");
-		const store = tx.store;
-
-		let processed = 0;
-		for (const word of dictionaryData.words) {
-			const entry = {
-				id: word.id,
-				kanji: word.kanji.map((k) => k.text),
-				kana: word.kana.map((k) => k.text),
-				kanjiData: word.kanji,
-				kanaData: word.kana,
-				sense: word.sense,
-			};
-
-			store.add(entry);
-
-			processed++;
-			if (processed % 1000 === 0) {
-				new Notice(
-					`Processed ${processed}/${dictionaryData.words.length} entries`
-				);
-			}
+		const existing = await db.get("dictionaries", meta.title);
+		if (existing) {
+			new Notice(`Dictionary "${meta.title}" already exists. Skipping.`);
+			return;
 		}
 
-		await tx.done;
+		await db.put("dictionaries", meta);
 
-		await db.put("metadata", {
-			key: "version",
-			value: dictionaryData.version,
-		});
-		await db.put("metadata", {
-			key: "dictDate",
-			value: dictionaryData.dictDate,
-		});
-		await db.put("metadata", {
-			key: "languages",
-			value: dictionaryData.languages.join(","),
-		});
+		const termFiles = Object.keys(zip.files).filter(
+			(filename) =>
+				filename.startsWith("term_bank_") && filename.endsWith(".json")
+		);
+
+		let processedCount = 0;
+		new Notice(`Importing ${meta.title}...`);
+
+		for (const filename of termFiles) {
+			const file = zip.file(filename);
+			if (!file) continue;
+
+			const content = await file.async("string");
+			const rawTerms: RawTermEntry[] = JSON.parse(content);
+
+			const tx = db.transaction("terms", "readwrite");
+			const termStore = tx.objectStore("terms");
+
+			const termsToAdd = rawTerms.map((entry) => {
+				const rawGlossary = entry.slice(5);
+				return {
+					expression: entry[0],
+					reading: entry[1],
+					tags: entry[2].split(" "),
+					rules: entry[3].split(" "),
+					score: entry[4],
+					glossary: rawGlossary as RawDefinition[],
+					dictionary: meta.title,
+				} as ProcessedTerm;
+			});
+
+			for (const term of termsToAdd) {
+				termStore.add(term);
+				processedCount++;
+			}
+
+			await tx.done;
+			console.log(`Processed batch: ${filename}`);
+		}
+
+		console.log(`Imported ${processedCount} terms from ${meta.title}`);
 	}
 }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -148,15 +148,17 @@ export class JapaneseScanner {
 		for (let i = scanLength; i > 0; i--) {
 			const currentText = text.substring(startOffset, startOffset + i);
 			if (!isJapanese(currentText)) continue;
-			const wordData = await this.plugin.dictionaryManager.lookup(
+
+			const results = await this.plugin.dictionaryManager.lookup(
 				currentText
 			);
 
-			if (wordData && wordData.length > 0) {
+			if (results && results.length > 0) {
 				this.highlightText(node, startOffset, startOffset + i);
-				console.log("Found word data:", wordData, "for", currentText);
-
-				// TODO: this.showPopup(textToScan);
+				console.log(
+					`Found ${results.length} results for "${currentText}":`,
+					results
+				);
 				return;
 			}
 		}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,15 +1,13 @@
 import JapanesePopupDictionary from "main";
 import { App, PluginSettingTab, Setting } from "obsidian";
-import { LANGUAGE_OPTIONS, TriggerKeys } from "./types";
+import { TriggerKeys } from "./types";
 
 export interface JapanesePopupDictionarySettings {
-	selectedLanguageCode: string;
 	triggerKey: string;
 	isDictionaryOn: boolean;
 }
 
 export const DEFAULT_SETTINGS: JapanesePopupDictionarySettings = {
-	selectedLanguageCode: LANGUAGE_OPTIONS[0].code,
 	triggerKey: TriggerKeys.None,
 	isDictionaryOn: true,
 };
@@ -24,24 +22,7 @@ export class SampleSettingTab extends PluginSettingTab {
 
 	display(): void {
 		const { containerEl } = this;
-
 		containerEl.empty();
-
-		new Setting(containerEl)
-			.setName("Target language")
-			.setDesc("Select the language for dictionary lookups.")
-			.addDropdown((dropdown) => {
-				LANGUAGE_OPTIONS.forEach((option) => {
-					dropdown.addOption(option.code, option.label);
-				});
-
-				dropdown
-					.setValue(this.plugin.settings.selectedLanguageCode)
-					.onChange(async (value) => {
-						this.plugin.settings.selectedLanguageCode = value;
-						await this.plugin.saveSettings();
-					});
-			});
 
 		new Setting(containerEl)
 			.setName("Dictionary toggle")
@@ -56,9 +37,9 @@ export class SampleSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName("Import dictionary")
+			.setName("Import Yomitan Dictionary")
 			.setDesc(
-				'Open the plugin folder to add your dictionary files and click the "Import dictionary" button to import it.'
+				"Open the plugin folder, place your Yomitan .zip file there, then click Import."
 			)
 			.addExtraButton((button) => {
 				button
@@ -70,20 +51,16 @@ export class SampleSettingTab extends PluginSettingTab {
 			})
 			.addButton((button) => {
 				button
-					.setButtonText("Import dictionary")
+					.setButtonText("Import .zip")
 					.setCta()
 					.onClick(async () => {
-						await this.plugin.importer.importDictionary(
-							this.plugin.settings.selectedLanguageCode
-						);
+						await this.plugin.importer.importDictionary();
 					});
 			});
 
 		new Setting(containerEl)
 			.setName("Hover modifier key")
-			.setDesc(
-				"Hold this key while hovering to trigger the dictionary. (Use 'None' to always scan)."
-			)
+			.setDesc("Hold this key while hovering to trigger.")
 			.addDropdown((dropdown) => {
 				dropdown
 					.addOption(TriggerKeys.None, "None (Always active)")

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,71 +1,66 @@
-type LanguageOption = {
-	label: string;
-	code: string;
-};
-
-export const LANGUAGE_OPTIONS: LanguageOption[] = [
-	{ label: "English", code: "eng" },
-	{ label: "Dutch", code: "dut" },
-	{ label: "French", code: "fre" },
-	{ label: "German", code: "ger" },
-	{ label: "Hungarian", code: "hun" },
-	{ label: "Russian", code: "rus" },
-	{ label: "Slovene", code: "slv" },
-	{ label: "Spanish", code: "spa" },
-	{ label: "Swedish", code: "swe" },
-];
-
-export interface JMDictGloss {
-	lang: string;
-	gender: string | null;
-	type: string | null;
-	text: string;
-}
-
-export interface JMDictSense {
-	partOfSpeech: string[];
-	appliesToKanji: string[];
-	appliesToKana: string[];
-	related: Array<[string, number?]>;
-	antonym: string[];
-	field: string[];
-	dialect: string[];
-	misc: string[];
-	info: string[];
-	languageSource: any[];
-	gloss: JMDictGloss[];
-}
-
-export interface JMDictKana {
-	common: boolean;
-	text: string;
-	tags: string[];
-	appliesToKanji: string[];
-}
-
-export interface JMDictKanji {
-	common: boolean;
-	text: string;
-	tags: string[];
-}
-
-export interface JMDictWord {
-	id: string;
-	kanji: JMDictKanji[];
-	kana: JMDictKana[];
-	sense: JMDictSense[];
-}
-
-export interface DictionaryData {
-	dictDate: string;
-	languages: string[];
-	version: string;
-	words: JMDictWord[];
-}
+import { DBSchema } from "idb";
 
 export enum TriggerKeys {
 	None = "None",
 	Ctrl = "Ctrl",
 	Alt = "Alt",
 	Shift = "Shift",
+}
+
+export interface YomitanIndex {
+	title: string;
+	format: number;
+	revision: string;
+	sequenced: boolean;
+	author: string;
+	url: string;
+	description: string;
+	attribution: string;
+}
+
+// Yomitan stores terms as an array: [expression, reading, tags, rules, score, ...glossary]
+// This is the raw format found in term_bank_*.json
+export type RawTermEntry = [
+	string, // 0: expression (kanji or kana)
+	string, // 1: reading (kana)
+	string, // 2: definition tags (space separated)
+	string, // 3: rules (space separated)
+	number, // 4: popularity/score
+	...RawDefinition[] // 5+: glossary definitions
+];
+
+export interface StructuredContent {
+	content: string | StructuredContent | (string | StructuredContent)[];
+	tag?: string;
+	lang?: string;
+	style?: Record<string, string>;
+	data?: Record<string, string>;
+	type?: string;
+}
+
+export type RawDefinition = string | StructuredContent;
+
+export interface ProcessedTerm {
+	expression: string;
+	reading: string;
+	tags: string[];
+	rules: string[];
+	score: number;
+	glossary: RawDefinition[];
+	dictionary: string; // To know which dict it came from
+}
+
+export interface YomitanDB extends DBSchema {
+	terms: {
+		key: number;
+		value: ProcessedTerm;
+		indexes: {
+			expression: string;
+			reading: string;
+		};
+	};
+	dictionaries: {
+		key: string; // dictionary title
+		value: YomitanIndex;
+	};
 }


### PR DESCRIPTION
Updated importer to support Yomitan .zip dictionaries, refactored database schema to store terms and metadata per dictionary, and improved lookup logic to use deinflection rules and new term structure. Removed language selection and legacy JMDict types, streamlining settings and code for Yomitan compatibility.