### PR TITLE
Handle structured content when extracting text

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -285,7 +285,7 @@ export class PopupManager {
 						element.addEventListener("click", (e) => {
 							e.preventDefault();
 							void this.handleLinkClick(
-								content.content as string,
+								this.extractTextContent(content.content),
 							);
 						});
 					}
@@ -320,5 +320,25 @@ export class PopupManager {
 		} catch (err) {
 			console.error("Link lookup failed:", err);
 		}
+	}
+
+	private extractTextContent(
+		content:
+			| string
+			| number
+			| StructuredContent
+			| (string | StructuredContent)[],
+	): string {
+		if (typeof content === "string") return content;
+		if (typeof content === "number") return String(content);
+		if (Array.isArray(content)) {
+			return content
+				.map((item) => this.extractTextContent(item))
+				.join("");
+		}
+
+		if (content.tag === "rt" || content.tag === "rp") return "";
+		if (content.content) return this.extractTextContent(content.content);
+		return "";
 	}
 }


### PR DESCRIPTION
Update popup link handling to properly extract plain text from StructuredContent instead of casting to string. Replace the direct cast with a new private method extractTextContent that recursively handles strings, numbers, arrays and nested StructuredContent, skips ruby annotation tags (rt/rp), and joins array items. This prevents incorrect text for link lookups and ignores non-visible annotation nodes.