### PR TITLE
Add isExternalLink util and use in popup

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,5 +1,6 @@
 import { DictionaryManager } from "./manager";
 import { ProcessedTerm, StructuredContent } from "./types";
+import { isExternalLink } from "./utils";
 
 export class PopupManager {
 	private dictionaryManager: DictionaryManager;
@@ -269,19 +270,12 @@ export class PopupManager {
 						: content.data?.class
 							? "popup-term-" + content.data?.class
 							: undefined,
-				href:
-					content.href && /^https?:\/\//i.test(content.href)
-						? content.href
-						: undefined,
+				href: isExternalLink(content.href) ? content.href : undefined,
 			},
 			(element) => {
 				if (content.content) {
 					// If it's a link without href, make it clickable to lookup
-					if (
-						content.tag === "a" &&
-						(!content.href ||
-							/^https?:\/\//i.test(content.href) === false)
-					) {
+					if (content.tag === "a" && !isExternalLink(content.href)) {
 						element.addEventListener("click", (e) => {
 							e.preventDefault();
 							void this.handleLinkClick(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,3 +3,8 @@ export function isJapanese(text: string) {
 	const output = /[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]/;
 	return output.test(text.charAt(0));
 }
+
+export function isExternalLink(href: string | undefined): boolean {
+	if (!href) return false;
+	return /^https?:\/\//i.test(href);
+}


### PR DESCRIPTION
Introduce isExternalLink(href) in src/utils.ts to centralize external link detection (returns false for falsy hrefs and tests https?://). Import and use this helper in PopupManager (src/popup.ts) to replace duplicated regex checks when setting anchor hrefs and deciding whether to attach internal lookup click handlers, improving readability and reducing duplicated logic.