### PR TITLE
Render form cell markers and add StructuredContent title

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -6,6 +6,14 @@ import { getFuriganaSegments } from "./furigana";
 export class PopupManager {
 	private dictionaryManager: DictionaryManager;
 	private popupEl: HTMLElement | null = null;
+	private readonly formCellMarkers: Record<string, string> = {
+		"form-pri": "\u25b3",
+		"form-irr": "\u2715",
+		"form-out": "\u53e4",
+		"form-old": "\u65e7",
+		"form-rare": "\u25bd",
+		"form-valid": "\u25c7",
+	};
 
 	constructor(dictionaryManager: DictionaryManager) {
 		this.dictionaryManager = dictionaryManager;
@@ -258,7 +266,8 @@ export class PopupManager {
 			| string
 			| number
 			| StructuredContent
-			| (string | StructuredContent)[],
+			| (string | number | StructuredContent)[],
+		insideTableHeader = false,
 	) {
 		if (typeof content === "string" || typeof content === "number") {
 			const text = String(content).trim();
@@ -270,16 +279,26 @@ export class PopupManager {
 
 		if (Array.isArray(content)) {
 			content.forEach((item) => {
-				this.renderStructuredContent(container, item);
+				this.renderStructuredContent(
+					container,
+					item,
+					insideTableHeader,
+				);
 			});
 			return;
 		}
 		const tagName = content.tag || "span";
+		const attrs: Record<string, string> = {};
+
+		if (content.lang) attrs.lang = content.lang;
+		if ((insideTableHeader || content.tag === "th") && content.title) {
+			attrs.title = content.title;
+		}
 
 		container.createEl(
 			tagName as keyof HTMLElementTagNameMap,
 			{
-				attr: content.lang ? { lang: content.lang } : undefined,
+				attr: Object.keys(attrs).length > 0 ? attrs : undefined,
 				cls:
 					content.tag === "ul"
 						? "popup-term-list"
@@ -289,7 +308,7 @@ export class PopupManager {
 				href: isExternalLink(content.href) ? content.href : undefined,
 			},
 			(element) => {
-				if (content.content) {
+				if (content.content !== undefined && content.content !== null) {
 					// If it's a link without href, make it clickable to lookup
 					if (content.tag === "a" && !isExternalLink(content.href)) {
 						element.addEventListener("click", (e) => {
@@ -299,10 +318,38 @@ export class PopupManager {
 							);
 						});
 					}
-					this.renderStructuredContent(element, content.content);
+					this.renderStructuredContent(
+						element,
+						content.content,
+						insideTableHeader || content.tag === "th",
+					);
 				}
+
+				this.renderFormCellMarker(element, content);
 			},
 		);
+	}
+
+	private renderFormCellMarker(
+		element: HTMLElement,
+		content: StructuredContent,
+	) {
+		if (content.tag !== "td" || element.innerText.trim() !== "") return;
+
+		const markerClass = content.data?.class;
+		if (!markerClass) return;
+
+		const marker = this.formCellMarkers[markerClass];
+		if (!marker) return;
+
+		const markerElement =
+			element.querySelector<HTMLElement>("span") ?? element.createSpan();
+		markerElement.setText(marker);
+
+		const title = this.extractTitle(content.content);
+		if (title) {
+			markerElement.setAttr("title", title);
+		}
 	}
 
 	private groupTermsByExpressionReading(
@@ -337,8 +384,10 @@ export class PopupManager {
 			| string
 			| number
 			| StructuredContent
-			| (string | StructuredContent)[],
+			| (string | number | StructuredContent)[]
+			| undefined,
 	): string {
+		if (content === undefined) return "";
 		if (typeof content === "string") return content;
 		if (typeof content === "number") return String(content);
 		if (Array.isArray(content)) {
@@ -350,5 +399,33 @@ export class PopupManager {
 		if (content.tag === "rt" || content.tag === "rp") return "";
 		if (content.content) return this.extractTextContent(content.content);
 		return "";
+	}
+
+	private extractTitle(
+		content:
+			| string
+			| number
+			| StructuredContent
+			| (string | number | StructuredContent)[]
+			| undefined,
+	): string {
+		if (
+			content === undefined ||
+			typeof content === "string" ||
+			typeof content === "number"
+		) {
+			return "";
+		}
+
+		if (Array.isArray(content)) {
+			for (const item of content) {
+				const title = this.extractTitle(item);
+				if (title) return title;
+			}
+			return "";
+		}
+
+		if (content.title) return content.title;
+		return this.extractTitle(content.content);
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,9 +30,14 @@ export type RawTermEntry = [
 ];
 
 export interface StructuredContent {
-	content: string | StructuredContent | (string | StructuredContent)[];
+	content?:
+		| string
+		| number
+		| StructuredContent
+		| (string | number | StructuredContent)[];
 	tag?: string;
 	lang?: string;
+	title?: string;
 	style?: Record<string, string>;
 	data?: Record<string, string>;
 	type?: string;

--- a/styles.css
+++ b/styles.css
@@ -55,6 +55,63 @@
 			padding: var(--size-4-1) var(--size-4-2);
 			text-align: left;
 		}
+
+		table td[class*="popup-term-form-"] {
+			text-align: center;
+
+			> span {
+				clip-path: circle();
+				display: inline-block;
+				font-weight: var(--font-semibold);
+				min-width: var(--size-4-2);
+				padding: 0 var(--size-4-1);
+			}
+		}
+
+		table .popup-term-form-special {
+			color: var(--text-error, --color-red);
+		}
+
+		table .popup-term-form-pri > span {
+			background: radial-gradient(
+				var(--color-green) 50%,
+				var(--background-primary) 100%
+			);
+			color: --color-white;
+		}
+
+		table .popup-term-form-irr > span {
+			background: radial-gradient(
+				var(--color-red) 50%,
+				var(--background-primary) 100%
+			);
+			color: --color-white;
+		}
+
+		table .popup-term-form-out > span,
+		table .popup-term-form-old > span {
+			background: radial-gradient(
+				var(--color-blue) 50%,
+				var(--background-primary) 100%
+			);
+			color: --color-white;
+		}
+
+		table .popup-term-form-rare > span {
+			background: radial-gradient(
+				var(--color-purple) 50%,
+				var(--background-primary) 100%
+			);
+			color: --color-white;
+		}
+
+		table .popup-term-form-valid > span {
+			background: radial-gradient(
+				var(--text-normal) 50%,
+				var(--background-primary) 100%
+			);
+			color: var(--background-primary, --color-white);
+		}
 	}
 
 	.popup-tag,


### PR DESCRIPTION
Add support for rendering form-cell markers in empty table cells and expose optional titles on StructuredContent. Introduces a formCellMarkers map of glyphs, a renderFormCellMarker method that inserts a marker span (and sets a tooltip from content.title or nested title) for empty td elements with a marker class, and early-exits when td already has content. StructuredContent.content now accepts numbers and is optional, and a title?: string field was added. renderStructuredContent now propagates an insideTableHeader flag to preserve title attributes on th, builds element attrs more robustly, and handles undefined/null content. Also add extractTitle helper and minor text-extraction guards. New CSS rules style the marker spans and add color/background variants for different form classes.